### PR TITLE
Configure weaver to comment out pod

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 {{$NEXT}}
 
+- Configured the pod weaving to leave commented out pod in place when weaving
+  when it's not at the end of the file;  This prevents changing line numbers and
+  creating un-tidy source code.
+
+
 0.12     2015-11-04
 
 - Added the Dist::Zilla::Role::PluginBundle::Config::Slicer role to the bundle

--- a/lib/Dist/Zilla/PluginBundle/MAXMIND.pm
+++ b/lib/Dist/Zilla/PluginBundle/MAXMIND.pm
@@ -318,6 +318,12 @@ sub _build_plugins {
         [
             UploadToCPAN => { pause_cfg_file => '.pause-maxmind' },
         ],
+        [
+            SurgicalPodWeaver => {
+                replacer           => 'replace_with_comment',
+                post_code_replacer => 'replace_with_nothing',
+            },
+        ],
 
         # from @Basic
         qw(
@@ -348,7 +354,6 @@ sub _build_plugins {
             MetaJSON
             MinimumPerl
             RewriteVersion
-            SurgicalPodWeaver
             ),
         qw(
             PodSyntaxTests


### PR DESCRIPTION
Primary advantages in this are:
- Doesn't screw up line numbering
- Doesn't produce output files that can potentially fail the tidy test
- Keeps pod (in the form of comments) inline if it was written inline

The configuration of this is such that if all the pod is at the end then this change does nothing;  Likewise pod that is at the end of the file isn't turned into comments simply to be duplicated below.
